### PR TITLE
Capture to pcap file in a temp directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ const { exec } = require('child_process');
 const { promisify } = require('util');
 const which = require('which');
 const fs = require('fs').promises;
+const path = require('path');
+const os = require('os');
 const execAsync = promisify(exec);
 const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
 const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
@@ -56,7 +58,7 @@ server.tool(
     try {
       const tsharkPath = await findTshark();
       const { interface, duration } = args;
-      const tempPcap = 'temp_capture.pcap';
+      const tempPcap = path.join(os.tmpdir(), `wiremcp_capture_${Date.now()}.pcap`);
       console.error(`Capturing packets on ${interface} for ${duration}s`);
 
       await execAsync(
@@ -108,7 +110,7 @@ server.tool(
     try {
       const tsharkPath = await findTshark();
       const { interface, duration } = args;
-      const tempPcap = 'temp_capture.pcap';
+      const tempPcap = path.join(os.tmpdir(), `wiremcp_summary_${Date.now()}.pcap`);
       console.error(`Capturing summary stats on ${interface} for ${duration}s`);
 
       await execAsync(
@@ -149,7 +151,7 @@ server.tool(
     try {
       const tsharkPath = await findTshark();
       const { interface, duration } = args;
-      const tempPcap = 'temp_capture.pcap';
+      const tempPcap = path.join(os.tmpdir(), `wiremcp_conversations_${Date.now()}.pcap`);
       console.error(`Capturing conversations on ${interface} for ${duration}s`);
 
       await execAsync(
@@ -190,7 +192,7 @@ server.tool(
     try {
       const tsharkPath = await findTshark();
       const { interface, duration } = args;
-      const tempPcap = 'temp_capture.pcap';
+      const tempPcap = path.join(os.tmpdir(), `wiremcp_threats_${Date.now()}.pcap`);
       console.error(`Capturing traffic on ${interface} for ${duration}s to check threats`);
 
       await execAsync(


### PR DESCRIPTION
Without this I was getting permission errors:

![Screenshot 2025-06-20 at 9 43 28 AM](https://github.com/user-attachments/assets/b32b9bf1-6e62-4438-8013-461851e4bf73)

```
Called capture_packets
Parameters:
  {
    "interface": "en0",
    "duration": 120
  }
Result:
  Error: Command failed: /opt/homebrew/bin/tshark -i en0 -w temp_capture.pcap -a duration:120
  Capturing on 'Wi-Fi: en0'
  tshark: The file to which the capture would be saved ("temp_capture.pcap") could not be opened: Read-only file system.
  0 packets captured
```

This is with Cursor 1.1.2 on Mac OS 14.2.1 (23C71):

```
Version: 1.1.2
VSCode Version: 1.96.2
Commit: 87ea1604be1f602f173c5fb67582e647fcef6c40
Date: 2025-06-13T00:30:10.108Z
Electron: 34.5.1
Chromium: 132.0.6834.210
Node.js: 20.19.0
V8: 13.2.152.41-electron.0
OS: Darwin arm64 23.2.0
```