### PR TITLE
Fix: Quote tshark and file paths for Windows compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// index.js - WireMCP Server
+// index.js - WireMCP Server (Fixed for Windows paths with spaces)
 const axios = require('axios');
 const { exec } = require('child_process');
 const { promisify } = require('util');
@@ -27,7 +27,7 @@ async function findTshark() {
     
     for (const path of fallbacks) {
       try {
-        await execAsync(`${path} -v`);
+        await execAsync(`"${path}" -v`);
         console.error(`Found tshark at fallback: ${path}`);
         return path;
       } catch (e) {
@@ -60,12 +60,12 @@ server.tool(
       console.error(`Capturing packets on ${interface} for ${duration}s`);
 
       await execAsync(
-        `${tsharkPath} -i ${interface} -w ${tempPcap} -a duration:${duration}`,
+        `"${tsharkPath}" -i "${interface}" -w "${tempPcap}" -a duration:${duration}`,
         { env: { ...process.env, PATH: `${process.env.PATH}:/usr/bin:/usr/local/bin:/opt/homebrew/bin` } }
       );
 
       const { stdout, stderr } = await execAsync(
-        `${tsharkPath} -r "${tempPcap}" -T json -e frame.number -e ip.src -e ip.dst -e tcp.srcport -e tcp.dstport -e tcp.flags -e frame.time -e http.request.method -e http.response.code`,
+        `"${tsharkPath}" -r "${tempPcap}" -T json -e frame.number -e ip.src -e ip.dst -e tcp.srcport -e tcp.dstport -e tcp.flags -e frame.time -e http.request.method -e http.response.code`,
         { env: { ...process.env, PATH: `${process.env.PATH}:/usr/bin:/usr/local/bin:/opt/homebrew/bin` } }
       );
       if (stderr) console.error(`tshark stderr: ${stderr}`);
@@ -112,12 +112,12 @@ server.tool(
       console.error(`Capturing summary stats on ${interface} for ${duration}s`);
 
       await execAsync(
-        `${tsharkPath} -i ${interface} -w ${tempPcap} -a duration:${duration}`,
+        `"${tsharkPath}" -i "${interface}" -w "${tempPcap}" -a duration:${duration}`,
         { env: { ...process.env, PATH: `${process.env.PATH}:/usr/bin:/usr/local/bin:/opt/homebrew/bin` } }
       );
 
       const { stdout, stderr } = await execAsync(
-        `${tsharkPath} -r "${tempPcap}" -qz io,phs`,
+        `"${tsharkPath}" -r "${tempPcap}" -qz io,phs`,
         { env: { ...process.env, PATH: `${process.env.PATH}:/usr/bin:/usr/local/bin:/opt/homebrew/bin` } }
       );
       if (stderr) console.error(`tshark stderr: ${stderr}`);
@@ -153,12 +153,12 @@ server.tool(
       console.error(`Capturing conversations on ${interface} for ${duration}s`);
 
       await execAsync(
-        `${tsharkPath} -i ${interface} -w ${tempPcap} -a duration:${duration}`,
+        `"${tsharkPath}" -i "${interface}" -w "${tempPcap}" -a duration:${duration}`,
         { env: { ...process.env, PATH: `${process.env.PATH}:/usr/bin:/usr/local/bin:/opt/homebrew/bin` } }
       );
 
       const { stdout, stderr } = await execAsync(
-        `${tsharkPath} -r "${tempPcap}" -qz conv,tcp`,
+        `"${tsharkPath}" -r "${tempPcap}" -qz conv,tcp`,
         { env: { ...process.env, PATH: `${process.env.PATH}:/usr/bin:/usr/local/bin:/opt/homebrew/bin` } }
       );
       if (stderr) console.error(`tshark stderr: ${stderr}`);
@@ -194,12 +194,12 @@ server.tool(
       console.error(`Capturing traffic on ${interface} for ${duration}s to check threats`);
 
       await execAsync(
-        `${tsharkPath} -i ${interface} -w ${tempPcap} -a duration:${duration}`,
+        `"${tsharkPath}" -i "${interface}" -w "${tempPcap}" -a duration:${duration}`,
         { env: { ...process.env, PATH: `${process.env.PATH}:/usr/bin:/usr/local/bin:/opt/homebrew/bin` } }
       );
 
       const { stdout } = await execAsync(
-        `${tsharkPath} -r "${tempPcap}" -T fields -e ip.src -e ip.dst`,
+        `"${tsharkPath}" -r "${tempPcap}" -T fields -e ip.src -e ip.dst`,
         { env: { ...process.env, PATH: `${process.env.PATH}:/usr/bin:/usr/local/bin:/opt/homebrew/bin` } }
       );
       const ips = [...new Set(stdout.split('\n').flatMap(line => line.split('\t')).filter(ip => ip && ip !== 'unknown'))];
@@ -315,7 +315,7 @@ server.tool(
 
       // Extract broad packet data
       const { stdout, stderr } = await execAsync(
-        `${tsharkPath} -r "${pcapPath}" -T json -e frame.number -e ip.src -e ip.dst -e tcp.srcport -e tcp.dstport -e udp.srcport -e udp.dstport -e http.host -e http.request.uri -e frame.protocols`,
+        `"${tsharkPath}" -r "${pcapPath}" -T json -e frame.number -e ip.src -e ip.dst -e tcp.srcport -e tcp.dstport -e udp.srcport -e udp.dstport -e http.host -e http.request.uri -e frame.protocols`,
         { env: { ...process.env, PATH: `${process.env.PATH}:/usr/bin:/usr/local/bin:/opt/homebrew/bin` } }
       );
       if (stderr) console.error(`tshark stderr: ${stderr}`);
@@ -378,13 +378,13 @@ server.tool(
   
         // Extract plaintext credentials
         const { stdout: plaintextOut } = await execAsync(
-          `${tsharkPath} -r "${pcapPath}" -T fields -e http.authbasic -e ftp.request.command -e ftp.request.arg -e telnet.data -e frame.number`,
+          `"${tsharkPath}" -r "${pcapPath}" -T fields -e http.authbasic -e ftp.request.command -e ftp.request.arg -e telnet.data -e frame.number`,
           { env: { ...process.env, PATH: `${process.env.PATH}:/usr/bin:/usr/local/bin:/opt/homebrew/bin` } }
         );
 
         // Extract Kerberos credentials
         const { stdout: kerberosOut } = await execAsync(
-          `${tsharkPath} -r "${pcapPath}" -T fields -e kerberos.CNameString -e kerberos.realm -e kerberos.cipher -e kerberos.type -e kerberos.msg_type -e frame.number`,
+          `"${tsharkPath}" -r "${pcapPath}" -T fields -e kerberos.CNameString -e kerberos.realm -e kerberos.cipher -e kerberos.type -e kerberos.msg_type -e frame.number`,
           { env: { ...process.env, PATH: `${process.env.PATH}:/usr/bin:/usr/local/bin:/opt/homebrew/bin` } }
         );
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// index.js - WireMCP Server (Fixed for Windows paths with spaces)
+// index.js - WireMCP Server
 const axios = require('axios');
 const { exec } = require('child_process');
 const { promisify } = require('util');


### PR DESCRIPTION
### Description:
This pull request improves Windows compatibility by ensuring all invocations of tshark and related file paths are wrapped in double quotes.
On Windows, paths such as C:\Program Files\Wireshark\tshark.exe may contain spaces, which can cause command execution errors if not properly quoted.
This change ensures that all [execAsync](vscode-file://vscode-app/c:/Users/andre/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) calls and fallback path checks work reliably on both Windows and Unix-like systems.

### Key changes:

All tshark and file path usages in [execAsync](vscode-file://vscode-app/c:/Users/andre/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) are now wrapped in double quotes.
Fallback path checks for tshark are also quoted.
No functional changes for Unix systems, but prevents failures on Windows.

### Why:
Without these quotes, users on Windows may encounter errors when running the server or tools if Wireshark is installed in a path with spaces.








